### PR TITLE
Batch Set Unicode Data to Reduce # of TXs Required to Init

### DIFF
--- a/contracts/UnicodeData.sol
+++ b/contracts/UnicodeData.sol
@@ -259,7 +259,7 @@ contract UnicodeData is Ownable {
     return char;
   }
 
-  /// @notice This is onlyty used by the owner to initialize and update Unicode character database
+  /// @notice This is only used by the owner to initialize and update Unicode character database
   /// @param _codePoint The Unicode code point to set
   /// @param _data The character data
   function set(uint32 _codePoint, Character calldata _data) external onlyOwner {

--- a/contracts/UnicodeData.sol
+++ b/contracts/UnicodeData.sol
@@ -259,13 +259,35 @@ contract UnicodeData is Ownable {
     return char;
   }
 
-  /// @notice This should only be used by the owner to initialize and update Unicode character database
+  /// @notice This is onlyty used by the owner to initialize and update Unicode character database
   /// @param _codePoint The Unicode code point to set
   /// @param _data The character data
   function set(uint32 _codePoint, Character calldata _data) external onlyOwner {
     // Require name to be non-empty!
     require(bytes(_data.name).length > 0, "character name must not be empty");
     characters[_codePoint] = _data;
+  }
+
+  /// @notice This is only used by the owner to initialize and update Unicode character database
+  /// @param _codePoints The Unicode code points to set
+  /// @param _data The list of character data to set
+  /// @dev Order matters! Order of _data must match the order of _codePoints
+  function setBatch(uint32[] calldata _codePoints, Character[] calldata _data)
+    external
+    onlyOwner
+  {
+    uint256 len = _codePoints.length;
+    uint256 i;
+
+    for (i = 0; i < len; i++) {
+      uint32 codePoint = _codePoints[i];
+      // Require name to be non-empty!
+      require(
+        bytes(_data[i].name).length > 0,
+        "character name must not be empty"
+      );
+      characters[codePoint] = _data[i];
+    }
   }
 
   // -------

--- a/docs/UnicodeData.md
+++ b/docs/UnicodeData.md
@@ -796,7 +796,7 @@ function renounceOwnership() external nonpayable
 function set(uint32 _codePoint, UnicodeData.Character _data) external nonpayable
 ```
 
-This should only be used by the owner to initialize and update Unicode character database
+This is onlyty used by the owner to initialize and update Unicode character database
 
 
 
@@ -806,6 +806,23 @@ This should only be used by the owner to initialize and update Unicode character
 |---|---|---|
 | _codePoint | uint32 | The Unicode code point to set
 | _data | UnicodeData.Character | The character data
+
+### setBatch
+
+```solidity
+function setBatch(uint32[] _codePoints, UnicodeData.Character[] _data) external nonpayable
+```
+
+This is only used by the owner to initialize and update Unicode character database
+
+*Order matters! Order of _data must match the order of _codePoints*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _codePoints | uint32[] | The Unicode code points to set
+| _data | UnicodeData.Character[] | The list of character data to set
 
 ### titlecase
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "unicode-eth",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/scripts/initialization.ts
+++ b/scripts/initialization.ts
@@ -67,7 +67,7 @@ export const initializeUnicodeData = async (contract: Contract) => {
       };
     } catch (err) {
       console.log(err);
-      console.log("failed to set:", char);
+      console.log("failed to set batch:", batch);
       failed = true;
       break;
     }

--- a/scripts/initialization.ts
+++ b/scripts/initialization.ts
@@ -3,6 +3,9 @@ import { Contract } from "ethers";
 import { Character } from "./types";
 import { getUnicodeData } from "./unicode-data";
 
+// roughly the number of characters we can set within the gas limit
+const BATCH_SIZE = 125;
+
 const charToParameter = (c: Character) =>
   Object.values({
     name: c.name,
@@ -25,7 +28,14 @@ export const initializeUnicodeData = async (contract: Contract) => {
   const characters = await getUnicodeData();
 
   const total = characters.length;
+  const numBatches = total / BATCH_SIZE;
   let count = 0;
+  let failed = false;
+  let batch = {
+    codes: [],
+    data: [],
+  };
+
   for (let char of characters) {
     // keep track of progress
     count++;
@@ -38,11 +48,42 @@ export const initializeUnicodeData = async (contract: Contract) => {
 
     // set each character
     const data = charToParameter(char);
+
+    // @ts-ignore
+    batch.codes = [...batch.codes, char.code];
+    // @ts-ignore
+    batch.data = [...batch.data, data];
+
+    if (batch.codes.length < BATCH_SIZE) {
+      continue;
+    }
+
     try {
-      await contract.set(char.code, data);
+      await contract.setBatch(batch.codes, batch.data);
+      // reset
+      batch = {
+        codes: [],
+        data: [],
+      };
     } catch (err) {
+      console.log(err);
       console.log("failed to set:", char);
+      failed = true;
       break;
     }
+  }
+
+  // set final batch if it exists
+  if (!batch.codes.length || failed) return;
+
+  try {
+    await contract.setBatch(batch.codes, batch.data);
+    // reset
+    batch = {
+      codes: [],
+      data: [],
+    };
+  } catch (err) {
+    console.log("failed to set final batch:", batch);
   }
 };


### PR DESCRIPTION
### Description

Adds a `batchSet` method for setting a list of characters rather than an individual. Lower number of transactions means lower overall gas cost to initialize.
